### PR TITLE
Extracting FdSets and its operations out of the MultiSocketSelector

### DIFF
--- a/kissnet.cpp
+++ b/kissnet.cpp
@@ -22,3 +22,4 @@ std::map<SOCKET, kissnet::tcp_ssl_socket*> KISSNET_API kissnet::tcp_ssl_socket::
 template<>
 std::map<SOCKET, kissnet::udp_socket*> KISSNET_API kissnet::udp_socket::sockets {};
 
+fd_set kissnet::FdSets::mFdSetNull;


### PR DESCRIPTION
Hi @NCirit , this is a WIP patch, which moves fd_set-specific operations out of MultiSocketSelector. During this development, a few more issues were noted:

* Copy/move constructors for MultiSocketSelector must be deleted
* fd_count is Windows-specific, and needs to be replaced with smth for Windows/Mac.

Could you please take over this PR and the items above :pray: 